### PR TITLE
Stability fixes and new menu options

### DIFF
--- a/DetailView.cpp
+++ b/DetailView.cpp
@@ -31,50 +31,51 @@ using namespace std;
 DetailView::DetailView(Map &mapData, GalaxyView *galaxyView, QWidget *parent) :
     QWidget(parent), mapData(mapData), galaxyView(galaxyView)
 {
+    // Create the left sidebar, showing details about the selected system.
+    QVBoxLayout *layout = new QVBoxLayout(this);
+
+    layout->addWidget(new QLabel("System Name:", this));
     name = new QLineEdit(this);
     connect(name, SIGNAL(editingFinished()), this, SLOT(NameChanged()));
+    layout->addWidget(name);
+
+
+    layout->addWidget(new QLabel("Government:", this));
     government = new QLineEdit(this);
     connect(government, SIGNAL(editingFinished()), this, SLOT(GovernmentChanged()));
-
-    QVBoxLayout *layout = new QVBoxLayout(this);
-    layout->addWidget(new QLabel("System Name:", this));
-    layout->addWidget(name);
-    layout->addWidget(new QLabel("Government:", this));
     layout->addWidget(government);
+    // Selecting the government field changes the system and link colors on the Galaxy map.
     government->installEventFilter(this);
 
+
+    // Add a table to display this system's default trade.
     tradeWidget = new QTreeWidget(this);
     tradeWidget->setIndentation(0);
     tradeWidget->setColumnCount(3);
-    QStringList tradeLabels;
-    tradeLabels.append("Commodity");
-    tradeLabels.append("Price");
-    tradeLabels.append("");
-    tradeWidget->setHeaderLabels(tradeLabels);
+    tradeWidget->setHeaderLabels({"Commodity", "Price", ""});
+    // Selecting a commodity field changes the system and link colors on the Galaxy map.
     connect(tradeWidget, SIGNAL(itemClicked(QTreeWidgetItem *, int)),
         this, SLOT(CommodityClicked(QTreeWidgetItem *, int)));
     layout->addWidget(tradeWidget);
 
+
+    // Add a table to display this system's fleets.
     fleets = new QTreeWidget(this);
     fleets->setIndentation(0);
     fleets->setColumnCount(2);
-    QStringList fleetLabels;
-    fleetLabels.append("Fleet Type");
-    fleetLabels.append("Period");
-    fleets->setHeaderLabels(fleetLabels);
+    fleets->setHeaderLabels({"Fleet Name", "Period"});
     fleets->setColumnWidth(0, 200);
     layout->addWidget(fleets);
 
+
+    // Add a table to display this system's minables (if any).
     minables = new QTreeWidget(this);
     minables->setIndentation(0);
     minables->setColumnCount(3);
-    QStringList minableLabels;
-    minableLabels.append("Minable Type");
-    minableLabels.append("count");
-    minableLabels.append("energy");
-    minables->setHeaderLabels(minableLabels);
+    minables->setHeaderLabels({"Minable", "Count", "Energy"});
     minables->setColumnWidth(0, 120);
     layout->addWidget(minables);
+
 
     setLayout(layout);
 }

--- a/DetailView.cpp
+++ b/DetailView.cpp
@@ -190,8 +190,7 @@ void DetailView::NameChanged()
     if(!system || system->Name() == name->text() || name->text().isEmpty())
         return;
 
-    auto it = mapData.Systems().find(name->text());
-    if(it != mapData.Systems().end())
+    if(mapData.Systems().count(name->text()))
     {
         QMessageBox::warning(this, "Duplicate name",
             "A system named \"" + name->text() + "\" already exists.");

--- a/DetailView.cpp
+++ b/DetailView.cpp
@@ -50,6 +50,7 @@ DetailView::DetailView(Map &mapData, GalaxyView *galaxyView, QWidget *parent) :
 
     // Add a table to display this system's default trade.
     tradeWidget = new QTreeWidget(this);
+    tradeWidget->setMinimumHeight(310);
     tradeWidget->setIndentation(0);
     tradeWidget->setColumnCount(3);
     tradeWidget->setHeaderLabels({"Commodity", "Price", ""});
@@ -65,6 +66,7 @@ DetailView::DetailView(Map &mapData, GalaxyView *galaxyView, QWidget *parent) :
     fleets->setColumnCount(2);
     fleets->setHeaderLabels({"Fleet Name", "Period"});
     fleets->setColumnWidth(0, 200);
+    fleets->setColumnWidth(1, 80);
     layout->addWidget(fleets);
 
 
@@ -73,7 +75,9 @@ DetailView::DetailView(Map &mapData, GalaxyView *galaxyView, QWidget *parent) :
     minables->setIndentation(0);
     minables->setColumnCount(3);
     minables->setHeaderLabels({"Minable", "Count", "Energy"});
-    minables->setColumnWidth(0, 120);
+    minables->setColumnWidth(0, 140);
+    minables->setColumnWidth(1, 70);
+    minables->setColumnWidth(2, 70);
     layout->addWidget(minables);
 
 

--- a/DetailView.cpp
+++ b/DetailView.cpp
@@ -249,7 +249,7 @@ void DetailView::FleetChanged(QTreeWidgetItem *item, int column)
 
     unsigned row = item->text(2).toInt();
     if(row == system->Fleets().size())
-        system->Fleets().push_back({item->text(0), item->text(1).toInt()});
+        system->Fleets().emplace_back(item->text(0), item->text(1).toInt());
     else if(item->text(0).isEmpty() && item->text(1).isEmpty())
         system->Fleets().erase(system->Fleets().begin() + row);
     else if(column == 0)
@@ -273,7 +273,7 @@ void DetailView::MinablesChanged(QTreeWidgetItem *item, int column)
 
     unsigned row = item->text(2).toInt();
     if(row == system->Minables().size())
-        system->Minables().push_back({item->text(0), item->text(1).toInt(), item->text(2).toDouble()});
+        system->Minables().emplace_back(item->text(0), item->text(1).toInt(), item->text(2).toDouble());
     else if(item->text(0).isEmpty() && item->text(1).isEmpty())
         system->Minables().erase(system->Minables().begin() + row);
     else if(column == 0)

--- a/DetailView.cpp
+++ b/DetailView.cpp
@@ -101,7 +101,10 @@ void DetailView::SetSystem(System *system)
     {
         name->clear();
         government->clear();
+
+        tradeWidget->clear();
         fleets->clear();
+        minables->clear();
     }
     update();
 }

--- a/DetailView.cpp
+++ b/DetailView.cpp
@@ -192,34 +192,32 @@ bool DetailView::eventFilter(QObject *object, QEvent *event)
 
 
 
+// Change the name of the selected system.
 void DetailView::NameChanged()
 {
-    if(!system || system->Name() == name->text() || name->text().isEmpty())
-        return;
-
-    if(mapData.Systems().count(name->text()))
+    name->blockSignals(true);
+    if(galaxyView && system && system->Name() != name->text())
     {
-        QMessageBox::warning(this, "Duplicate name",
-            "A system named \"" + name->text() + "\" already exists.");
+        // Attempt the name change in GalaxyView, to update both this and SystemView.
+        if(!galaxyView->RenameSystem(system->Name(), name->text()))
+            name->setText(system->Name());
     }
-    else
-    {
-        mapData.RenameSystem(system->Name(), name->text());
-        mapData.SetChanged();
-        galaxyView->update();
-    }
+    name->blockSignals(false);
 }
 
 
 
 void DetailView::GovernmentChanged()
 {
-    if(!system || system->Government() == government->text() || government->text().isEmpty())
+    const QString &newGov = government->text();
+    if(!system || system->Government() == newGov || newGov.isEmpty())
         return;
 
-    system->SetGovernment(government->text());
-    galaxyView->SetGovernment(government->text());
+    system->SetGovernment(newGov);
+    galaxyView->SetGovernment(newGov);
     mapData.SetChanged();
+
+    // Refresh the Galaxy map since it is using a new Government color.
     galaxyView->update();
 }
 

--- a/Galaxy.cpp
+++ b/Galaxy.cpp
@@ -19,6 +19,13 @@ using namespace std;
 
 
 
+Galaxy::Galaxy(const DataNode &node)
+{
+    Load(node);
+}
+
+
+
 void Galaxy::Load(const DataNode &node)
 {
     if(node.Size() >= 2)

--- a/Galaxy.h
+++ b/Galaxy.h
@@ -25,6 +25,9 @@ class DataWriter;
 
 class Galaxy {
 public:
+    Galaxy() = default;
+    Galaxy(const DataNode &node);
+
     void Load(const DataNode &node);
     void Save(DataWriter &file) const;
 

--- a/GalaxyView.cpp
+++ b/GalaxyView.cpp
@@ -215,7 +215,7 @@ void GalaxyView::DeleteSystem()
         while(!system->Links().empty())
         {
             // The system to be deleted may have a link to a "plugin" system.
-            const auto &it = mapData.Systems().find(*system->Links().begin());
+            auto it = mapData.Systems().find(*system->Links().begin());
             if(it != mapData.Systems().end())
                 system->ToggleLink(&it->second);
             // Only this system's endpoint can be modified.
@@ -369,7 +369,7 @@ void GalaxyView::RandomizeCommodity()
                 for(const System *source : sources)
                     for(const QString &name : source->Links())
                     {
-                        const auto &it = mapData.Systems().find(name);
+                        auto it = mapData.Systems().find(name);
                         if(it == mapData.Systems().end() || done.count(&it->second))
                             continue;
                         const System *link = &it->second;

--- a/GalaxyView.cpp
+++ b/GalaxyView.cpp
@@ -229,7 +229,7 @@ void GalaxyView::RandomizeCommodity()
         // loosen the quota a little bit.
         vector<int> quota;
         for(int weight : binIt->second)
-            quota.push_back((connected.size() * weight) / 100 + tries / 4 + 1);
+            quota.emplace_back((connected.size() * weight) / 100 + tries / 4 + 1);
         
         vector<const System *> unassigned;
         map<const System *, int> low;

--- a/GalaxyView.cpp
+++ b/GalaxyView.cpp
@@ -150,6 +150,54 @@ void GalaxyView::CreateSystem()
 
 
 
+// Change the name of a system, which involves creating a new pointer
+// and updating the system and detail views with it.
+bool GalaxyView::RenameSystem(const QString &from, const QString &to)
+{
+    if(!mapData.Systems().count(from))
+    {
+        QMessageBox::warning(this, "Missing name",
+            "A system named \"" + from + "\" didn't exist.");
+        mapData.Systems()[from];
+        mapData.SetChanged();
+        update();
+        return false;
+    }
+    // If the desired name is empty, prompt to delete the system.
+    else if(to.isEmpty())
+    {
+        if(systemView && systemView->Selected())
+            DeleteSystem();
+        else
+            return false;
+    }
+    else if(mapData.Systems().count(to))
+    {
+        QMessageBox::warning(this, "Duplicate name",
+            "A system named \"" + to + "\" already exists.");
+        return false;
+    }
+    else
+    {
+        mapData.RenameSystem(from, to);
+        mapData.SetChanged();
+
+        // Update the system pointed to by the two views, as the old pointer is invalid.
+        System *newSystem = &mapData.Systems()[to];
+        if(systemView)
+            systemView->Select(newSystem);
+        if(detailView)
+            detailView->SetSystem(newSystem);
+
+        // Redraw the Galaxy map using the new system's name.
+        update();
+    }
+
+    return true;
+}
+
+
+
 // Delete a system, and remove any string references to it (i.e. links).
 void GalaxyView::DeleteSystem()
 {

--- a/GalaxyView.cpp
+++ b/GalaxyView.cpp
@@ -211,9 +211,17 @@ void GalaxyView::DeleteSystem()
     {
         // Deselect this system.
         systemView->Select(nullptr);
-        // Remove all links from this system (and the corresponding return links).
+        // Remove all links from this system (and the corresponding return links, if able).
         while(!system->Links().empty())
-            system->ToggleLink(&mapData.Systems().find(*system->Links().begin())->second);
+        {
+            // The system to be deleted may have a link to a "plugin" system.
+            const auto &it = mapData.Systems().find(*system->Links().begin());
+            if(it != mapData.Systems().end())
+                system->ToggleLink(&it->second);
+            // Only this system's endpoint can be modified.
+            else
+                system->ChangeLink(*system->Links().begin(), QString());
+        }
 
         // Remove this system from known systems.
         mapData.Systems().erase(system->Name());

--- a/GalaxyView.cpp
+++ b/GalaxyView.cpp
@@ -169,8 +169,16 @@ void GalaxyView::DeleteSystem()
         mapData.Systems().erase(system->Name());
         mapData.SetChanged();
     }
+    update();
 }
 
+
+
+void GalaxyView::Recenter()
+{
+    Center();
+    update();
+}
 
 
 void GalaxyView::RandomizeCommodity()

--- a/GalaxyView.cpp
+++ b/GalaxyView.cpp
@@ -136,6 +136,7 @@ void GalaxyView::KeyPress(QKeyEvent *event)
 
 
 
+// Delete a system, and remove any string references to it (i.e. links).
 void GalaxyView::DeleteSystem()
 {
     if(!systemView || !systemView->Selected())
@@ -146,12 +147,14 @@ void GalaxyView::DeleteSystem()
         "Are you sure you want to delete \"" + system->Name() + "\"?");
     if(button == QMessageBox::Yes)
     {
+        // Deselect this system.
         systemView->Select(nullptr);
+        // Remove all links from this system (and the corresponding return links).
         while(!system->Links().empty())
-            system->ToggleLink(&mapData.Systems().find(system->Links().front())->second);
+            system->ToggleLink(&mapData.Systems().find(*system->Links().begin())->second);
 
-        auto it = mapData.Systems().find(system->Name());
-        mapData.Systems().erase(it);
+        // Remove this system from known systems.
+        mapData.Systems().erase(system->Name());
         mapData.SetChanged();
     }
 }

--- a/GalaxyView.cpp
+++ b/GalaxyView.cpp
@@ -206,11 +206,8 @@ void GalaxyView::RandomizeCommodity()
         connected.insert(system);
         
         for(const QString &name : system->Links())
-        {
-            auto it = mapData.Systems().find(name);
-            if(it != mapData.Systems().end())
-                edge.push(&it->second);
-        }
+            if(mapData.Systems().count(name))
+                edge.push(&mapData.Systems()[name]);
     }
     
     // Commodity parameters.
@@ -316,7 +313,7 @@ void GalaxyView::RandomizeCommodity()
                 for(const System *source : sources)
                     for(const QString &name : source->Links())
                     {
-                        auto it = mapData.Systems().find(name);
+                        const auto &it = mapData.Systems().find(name);
                         if(it == mapData.Systems().end() || done.count(&it->second))
                             continue;
                         const System *link = &it->second;
@@ -352,14 +349,12 @@ void GalaxyView::RandomizeCommodity()
         int count = 0;
         int sum = 0;
         for(const QString &link : system->Links())
-        {
-            auto it = mapData.Systems().find(link);
-            if(it == mapData.Systems().end())
-                continue;
-            
-            sum += rough[&it->second];
-            ++count;
-        }
+            if(mapData.Systems().count(link))
+            {
+                sum += rough[&mapData.Systems()[link]];
+                ++count;
+            }
+
         if(!count)
             sum = rough[system];
         else

--- a/GalaxyView.cpp
+++ b/GalaxyView.cpp
@@ -104,6 +104,7 @@ void GalaxyView::SetDetailView(DetailView *view)
 
 
 
+// Color the map by this commodity.
 void GalaxyView::SetCommodity(const QString &name)
 {
     if(commodity != name)
@@ -116,6 +117,7 @@ void GalaxyView::SetCommodity(const QString &name)
 
 
 
+// Color the map by this government.
 void GalaxyView::SetGovernment(const QString &name)
 {
     if(government != name)
@@ -179,6 +181,7 @@ void GalaxyView::Recenter()
     Center();
     update();
 }
+
 
 
 void GalaxyView::RandomizeCommodity()
@@ -339,7 +342,7 @@ void GalaxyView::RandomizeCommodity()
     
     // Assign each star system a value based on its bin.
     map<const System *, int> rough;
-    for(auto &it : bin)
+    for(const auto &it : bin)
         rough[it.first] = base + (rand() % 100) + 100 * it.second;
     
     // Smooth out the values by averaging each system with the average of all
@@ -393,6 +396,8 @@ void GalaxyView::mousePressEvent(QMouseEvent *event)
             CreateSystem(origin);
         return;
     }
+    // An existing system was clicked. Select it, or toggle a link with the
+    // already-selected system.
     if(event->button() == Qt::LeftButton)
     {
         dragTime.start();
@@ -400,6 +405,9 @@ void GalaxyView::mousePressEvent(QMouseEvent *event)
         if(systemView)
         {
             systemView->Select(dragSystem);
+            // Update the coloring scheme if coloring by government.
+            if(!government.isEmpty() && !dragSystem->Government().isEmpty())
+                government = dragSystem->Government();
             update();
         }
     }
@@ -438,6 +446,7 @@ void GalaxyView::mouseDoubleClickEvent(QMouseEvent *event)
 
 
 
+// Drag either the selected system, or the background.
 void GalaxyView::mouseMoveEvent(QMouseEvent *event)
 {
     if(!(event->buttons() & Qt::LeftButton))
@@ -460,6 +469,7 @@ void GalaxyView::mouseMoveEvent(QMouseEvent *event)
 
 
 
+// Zoom in or out.
 void GalaxyView::wheelEvent(QWheelEvent *event)
 {
     QVector2D point(event->pos());
@@ -498,6 +508,7 @@ void GalaxyView::paintEvent(QPaintEvent */*event*/)
         painter.drawPixmap(pos, sprite);
     }
 
+    // Draw the links between systems.
     painter.setBrush(Qt::NoBrush);
     for(const auto &it : mapData.Systems())
     {
@@ -523,6 +534,7 @@ void GalaxyView::paintEvent(QPaintEvent */*event*/)
         }
     }
 
+    // Draw the systems, colored by commodity or if the government is the selected government.
     for(const auto &it : mapData.Systems())
     {
         QPointF pos = it.second.Position().toPointF();
@@ -546,6 +558,7 @@ void GalaxyView::paintEvent(QPaintEvent */*event*/)
         painter.drawText(pos + QPointF(5, 5), it.first);
     }
 
+    // Draw the selection circle and neighbor radius ring.
     painter.setPen(mediumPen);
     painter.setBrush(Qt::NoBrush);
     if(systemView && systemView->Selected())

--- a/GalaxyView.h
+++ b/GalaxyView.h
@@ -44,6 +44,7 @@ signals:
 
 public slots:
     void CreateSystem();
+    bool RenameSystem(const QString &from, const QString &to);
     void DeleteSystem();
     void Recenter();
     void RandomizeCommodity();

--- a/GalaxyView.h
+++ b/GalaxyView.h
@@ -45,6 +45,7 @@ signals:
 public slots:
     void CreateSystem();
     void DeleteSystem();
+    void Recenter();
     void RandomizeCommodity();
 
 protected:

--- a/GalaxyView.h
+++ b/GalaxyView.h
@@ -23,8 +23,8 @@ class Map;
 class System;
 class SystemView;
 
+class QPoint;
 class QTabWidget;
-
 
 
 class GalaxyView : public QWidget
@@ -43,6 +43,7 @@ public:
 signals:
 
 public slots:
+    void CreateSystem();
     void DeleteSystem();
     void RandomizeCommodity();
 
@@ -56,6 +57,7 @@ protected:
 
 private:
     QVector2D MapPoint(QPoint pos) const;
+    void CreateSystem(const QVector2D &origin);
 
 
 private:

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -63,20 +63,31 @@ void MainWindow::DoOpen(const QString &path)
     systemView->Select(nullptr);
     planetView->Reinitialize();
     tabs->setCurrentWidget(galaxyView);
-    update();
     galaxyView->update();
+    update();
 }
 
 
 
 void MainWindow::NewMap()
 {
+    if(map.IsChanged())
+    {
+        QMessageBox::StandardButton button = QMessageBox::question(this, "Save the current map?",
+                "There are unsaved changes. Would you like to save them before making a new map?");
+        if(button == QMessageBox::Yes)
+            SaveAs();
+        else if(button != QMessageBox::No)
+            return;
+    }
+
     // Start in the previous map file's directory.
     QString dir = map.DataDirectory();
     QString path = QFileDialog::getSaveFileName(this, "Create map file", dir, "*.txt");
     if(!path.isEmpty())
     {
         // Create the empty map file.
+        map = Map();
         map.Save(path);
         // Initialize the editor with the empty map.
         DoOpen(path);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -80,6 +80,8 @@ void MainWindow::NewMap()
         map.Save(path);
         // Initialize the editor with the empty map.
         DoOpen(path);
+        // Create a system at (0, 0).
+        galaxyView->CreateSystem();
     }
 }
 
@@ -257,68 +259,72 @@ void MainWindow::CreateMenus()
 
     // Galaxy Menu:
     galaxyMenu = menuBar()->addMenu("Galaxy");
+    {
+        QAction *createSystemAction = galaxyMenu->addAction("Create System");
+        connect(createSystemAction, SIGNAL(triggered()), galaxyView, SLOT(CreateSystem()));
 
-    QAction *deleteSystemAction = galaxyMenu->addAction("Delete System");
-    connect(deleteSystemAction, SIGNAL(triggered()), galaxyView, SLOT(DeleteSystem()));
-    deleteSystemAction->setShortcut(QKeySequence(Qt::Key_Backspace));
+        QAction *deleteSystemAction = galaxyMenu->addAction("Delete System");
+        connect(deleteSystemAction, SIGNAL(triggered()), galaxyView, SLOT(DeleteSystem()));
+        deleteSystemAction->setShortcut(QKeySequence(Qt::Key_Backspace));
 
-    QAction *randomizeCommodityAction = galaxyMenu->addAction("Randomize Commodity");
-    connect(randomizeCommodityAction, SIGNAL(triggered()), galaxyView, SLOT(RandomizeCommodity()));
-    randomizeCommodityAction->setShortcut(QKeySequence("C"));
-
+        QAction *randomizeCommodityAction = galaxyMenu->addAction("Randomize Commodity");
+        connect(randomizeCommodityAction, SIGNAL(triggered()), galaxyView, SLOT(RandomizeCommodity()));
+        randomizeCommodityAction->setShortcut(QKeySequence("C"));
+    }
 
     // System Menu:
     systemMenu = menuBar()->addMenu("System");
+    {
+        QAction *randomInhabited = systemMenu->addAction("Randomize (Inhabited)");
+        connect(randomInhabited, SIGNAL(triggered()), systemView, SLOT(RandomizeInhabited()));
+        randomInhabited->setShortcut(QKeySequence("I"));
 
-    QAction *randomInhabited = systemMenu->addAction("Randomize (Inhabited)");
-    connect(randomInhabited, SIGNAL(triggered()), systemView, SLOT(RandomizeInhabited()));
-    randomInhabited->setShortcut(QKeySequence("I"));
+        QAction *randomSystem = systemMenu->addAction("Randomize");
+        connect(randomSystem, SIGNAL(triggered()), systemView, SLOT(Randomize()));
+        randomSystem->setShortcut(QKeySequence("R"));
 
-    QAction *randomSystem = systemMenu->addAction("Randomize");
-    connect(randomSystem, SIGNAL(triggered()), systemView, SLOT(Randomize()));
-    randomSystem->setShortcut(QKeySequence("R"));
+        QAction *randomUninhabited = systemMenu->addAction("Randomize (Uninhabited)");
+        connect(randomUninhabited, SIGNAL(triggered()), systemView, SLOT(RandomizeUninhabited()));
+        randomUninhabited->setShortcut(QKeySequence("U"));
 
-    QAction *randomUninhabited = systemMenu->addAction("Randomize (Uninhabited)");
-    connect(randomUninhabited, SIGNAL(triggered()), systemView, SLOT(RandomizeUninhabited()));
-    randomUninhabited->setShortcut(QKeySequence("U"));
+        systemMenu->addSeparator();
 
-    systemMenu->addSeparator();
+        QAction *changeAsteroids = systemMenu->addAction("Change Asteroids");
+        connect(changeAsteroids, SIGNAL(triggered()), systemView, SLOT(ChangeAsteroids()));
+        changeAsteroids->setShortcut(QKeySequence("A"));
 
-    QAction *changeAsteroids = systemMenu->addAction("Change Asteroids");
-    connect(changeAsteroids, SIGNAL(triggered()), systemView, SLOT(ChangeAsteroids()));
-    changeAsteroids->setShortcut(QKeySequence("A"));
+        QAction *changeMinables = systemMenu->addAction("Change Minables");
+        connect(changeMinables, SIGNAL(triggered()), systemView, SLOT(ChangeMinables()));
+        changeMinables->setShortcut(QKeySequence("H"));
 
-    QAction *changeMinables = systemMenu->addAction("Change Minables");
-    connect(changeMinables, SIGNAL(triggered()), systemView, SLOT(ChangeMinables()));
-    changeMinables->setShortcut(QKeySequence("H"));
+        systemMenu->addSeparator();
 
-    systemMenu->addSeparator();
+        QAction *changeStar = systemMenu->addAction("Change Star");
+        connect(changeStar, SIGNAL(triggered()), systemView, SLOT(ChangeStar()));
+        changeStar->setShortcut(QKeySequence("T"));
 
-    QAction *changeStar = systemMenu->addAction("Change Star");
-    connect(changeStar, SIGNAL(triggered()), systemView, SLOT(ChangeStar()));
-    changeStar->setShortcut(QKeySequence("T"));
+        QAction *addPlanet = systemMenu->addAction("Add/Change Planet");
+        connect(addPlanet, SIGNAL(triggered()), systemView, SLOT(ChangePlanet()));
+        addPlanet->setShortcut(QKeySequence("P"));
 
-    QAction *addPlanet = systemMenu->addAction("Add/Change Planet");
-    connect(addPlanet, SIGNAL(triggered()), systemView, SLOT(ChangePlanet()));
-    addPlanet->setShortcut(QKeySequence("P"));
+        QAction *addMoon = systemMenu->addAction("Add/Change Moon");
+        connect(addMoon, SIGNAL(triggered()), systemView, SLOT(ChangeMoon()));
+        addMoon->setShortcut(QKeySequence("M"));
 
-    QAction *addMoon = systemMenu->addAction("Add/Change Moon");
-    connect(addMoon, SIGNAL(triggered()), systemView, SLOT(ChangeMoon()));
-    addMoon->setShortcut(QKeySequence("M"));
+        QAction *addStation = systemMenu->addAction("Add/Change Station");
+        connect(addStation, SIGNAL(triggered()), systemView, SLOT(ChangeStation()));
+        addStation->setShortcut(QKeySequence("S"));
 
-    QAction *addStation = systemMenu->addAction("Add/Change Station");
-    connect(addStation, SIGNAL(triggered()), systemView, SLOT(ChangeStation()));
-    addStation->setShortcut(QKeySequence("S"));
+        QAction *deleteObject = systemMenu->addAction("Delete Object");
+        connect(deleteObject, SIGNAL(triggered()), systemView, SLOT(DeleteObject()));
+        deleteObject->setShortcut(QKeySequence("X"));
 
-    QAction *deleteObject = systemMenu->addAction("Delete Object");
-    connect(deleteObject, SIGNAL(triggered()), systemView, SLOT(DeleteObject()));
-    deleteObject->setShortcut(QKeySequence("X"));
+        systemMenu->addSeparator();
 
-    systemMenu->addSeparator();
-
-    QAction *pause = systemMenu->addAction("Pause/Unpause");
-    connect(pause, SIGNAL(triggered()), systemView, SLOT(Pause()));
-    pause->setShortcut(QKeySequence(Qt::Key_Space));
+        QAction *pause = systemMenu->addAction("Pause/Unpause");
+        connect(pause, SIGNAL(triggered()), systemView, SLOT(Pause()));
+        pause->setShortcut(QKeySequence(Qt::Key_Space));
+    }
 
     // Activate only the menu for the current tab.
     TabChanged(0);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -267,6 +267,11 @@ void MainWindow::CreateMenus()
         connect(deleteSystemAction, SIGNAL(triggered()), galaxyView, SLOT(DeleteSystem()));
         deleteSystemAction->setShortcut(QKeySequence(Qt::Key_Backspace));
 
+        galaxyMenu->addSeparator();
+        QAction *centerAction = galaxyMenu->addAction("Recenter View");
+        connect(centerAction, SIGNAL(triggered()), galaxyView, SLOT(Recenter()));
+        galaxyMenu->addSeparator();
+
         QAction *randomizeCommodityAction = galaxyMenu->addAction("Randomize Commodity");
         connect(randomizeCommodityAction, SIGNAL(triggered()), galaxyView, SLOT(RandomizeCommodity()));
         randomizeCommodityAction->setShortcut(QKeySequence("C"));

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -227,7 +227,7 @@ void MainWindow::CreateWidgets()
     galaxyView->SetDetailView(detailView);
 
     systemView = new SystemView(map, detailView, tabs, tabs);
-    const auto &it = map.Systems().find("Sol");
+    auto it = map.Systems().find("Sol");
     if(it != map.Systems().end())
         systemView->Select(&it->second);
     galaxyView->SetSystemView(systemView);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -209,13 +209,14 @@ void MainWindow::CreateWidgets()
 
     galaxyView = new GalaxyView(map, tabs, tabs);
 
+    // Initialize the sidebar with the system, government, fleet, trade, and minables data.
     detailView = new DetailView(map, galaxyView, box);
     detailView->setMinimumWidth(300);
     detailView->setMaximumWidth(300);
     galaxyView->SetDetailView(detailView);
 
     systemView = new SystemView(map, detailView, tabs, tabs);
-    auto it = map.Systems().find("Sol");
+    const auto &it = map.Systems().find("Sol");
     if(it != map.Systems().end())
         systemView->Select(&it->second);
     galaxyView->SetSystemView(systemView);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -90,7 +90,6 @@ void MainWindow::Save()
 
 
 
-
 void MainWindow::Quit()
 {
     close();

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -40,8 +40,10 @@ public:
     void DoOpen(const QString &path);
 
 public slots:
+    void NewMap();
     void Open();
     void Save();
+    void SaveAs();
     void Quit();
 
     void TabChanged(int);

--- a/Map.cpp
+++ b/Map.cpp
@@ -207,22 +207,21 @@ QString Map::PriceLevel(const QString &commodity, int price) const
 
 
 
-// Rename a system. This requires updating all the systems that link to it.
+// Rename a system. This requires updating all the known systems that link to it.
 void Map::RenameSystem(const QString &from, const QString &to)
 {
-    auto it = systems.find(from);
-    if(it == systems.end() || systems.find(to) != systems.end())
+    // If the desired name is taken, or the current name doesn't exist, bail out.
+    if(systems.count(to) || !systems.count(from))
         return;
 
-    System &renamed = systems[to] = it->second;
+    System &renamed = systems[to] = systems[from];
     renamed.SetName(to);
-    for(const QString &link : it->second.Links())
-    {
-        auto oit = systems.find(link);
-        if(oit != systems.end())
-            oit->second.ChangeLink(from, to);
-    }
-    systems.erase(it);
+    for(const QString &link : systems[from].Links())
+        if(systems.count(link))
+            systems[link].ChangeLink(from, to);
+
+    // Erase the original name's system definition.
+    systems.erase(from);
 }
 
 

--- a/Map.cpp
+++ b/Map.cpp
@@ -42,10 +42,7 @@ void Map::Load(const QString &path)
         else if(node.Token(0) == "system" && node.Size() >= 2)
             systems[node.Token(1)].Load(node);
         else if(node.Token(0) == "galaxy")
-        {
-            galaxies.push_back(Galaxy());
-            galaxies.back().Load(node);
-        }
+            galaxies.emplace_back(node);
         else
             unparsed.push_back(node);
     }
@@ -53,15 +50,14 @@ void Map::Load(const QString &path)
     QString commodityPath = dataDirectory + "commodities.txt";
     DataFile tradeData(commodityPath);
 
+    // Load in "standard" commodities - those that supply a category, low, and high price.
+    // "Special" commodities that are only used as names for mission cargo are not loaded.
     for(const DataNode &node : tradeData)
         if(node.Token(0) == "trade")
             for(const DataNode &child : node)
                 if(child.Token(0) == "commodity" && child.Size() >= 4)
-                {
-                    int low = static_cast<int>(child.Value(2));
-                    int high = static_cast<int>(child.Value(3));
-                    commodities.push_back({child.Token(1), low, high});
-                }
+                    commodities.emplace_back(child.Token(1), child.Value(2), child.Value(3));
+
     isChanged = false;
 }
 

--- a/Map.cpp
+++ b/Map.cpp
@@ -28,6 +28,7 @@ void Map::Load(const QString &path)
     *this = Map();
 
     dataDirectory = path.left(path.lastIndexOf('/'));
+    fileName = path.right(path.lastIndexOf('/'));
     QString rootDir = dataDirectory.left(dataDirectory.lastIndexOf('/'));
     dataDirectory += "/";
     SpriteSet::SetRootPath(rootDir + "/images/");
@@ -63,8 +64,9 @@ void Map::Load(const QString &path)
 
 
 
-void Map::Save(const QString &path) const
+void Map::Save(const QString &path)
 {
+    fileName = path.right(path.lastIndexOf('/'));
     DataWriter file(path);
     file.WriteRaw(comments);
     file.Write();
@@ -97,6 +99,13 @@ void Map::Save(const QString &path) const
 const QString &Map::DataDirectory() const
 {
     return dataDirectory;
+}
+
+
+
+const QString &Map::FileName() const
+{
+    return fileName;
 }
 
 
@@ -198,8 +207,7 @@ QString Map::PriceLevel(const QString &commodity, int price) const
 
 
 
-// Rename a system. This involves changing all the systems that link to it
-// and moving it to a new place in the map.
+// Rename a system. This requires updating all the systems that link to it.
 void Map::RenameSystem(const QString &from, const QString &to)
 {
     auto it = systems.find(from);
@@ -219,6 +227,8 @@ void Map::RenameSystem(const QString &from, const QString &to)
 
 
 
+// Rename a planet. The editor does not support planets sharing a name with
+// a system, or renaming an object to share a planet definition (i.e. wormholes).
 void Map::RenamePlanet(StellarObject *object, const QString &name)
 {
     if(!object || systems.find(name) != systems.end())
@@ -227,7 +237,9 @@ void Map::RenamePlanet(StellarObject *object, const QString &name)
     auto it = planets.find(object->GetPlanet());
     if(it != planets.end())
     {
+        // Copy the existing definition to the new name.
         planets[name] = it->second;
+        // Erase the previous definition.
         planets.erase(it);
     }
     planets[name].SetName(name);

--- a/Map.cpp
+++ b/Map.cpp
@@ -216,6 +216,9 @@ void Map::RenameSystem(const QString &from, const QString &to)
 
     System &renamed = systems[to] = systems[from];
     renamed.SetName(to);
+    // Links to "plugin" systems (i.e. those not a part of this map file)
+    // are kept, but the returning link from the plugin system to this
+    // system will not exist. (There is no way to update it.)
     for(const QString &link : systems[from].Links())
         if(systems.count(link))
             systems[link].ChangeLink(from, to);

--- a/Map.h
+++ b/Map.h
@@ -46,7 +46,10 @@ public:
     const std::map<QString, Planet> &Planets() const;
 
     // Access the commodity data:
-    struct Commodity { QString name; int low; int high; };
+    struct Commodity {
+        QString name; int low; int high;
+        Commodity(const QString &name, int low, int high) : name(name), low(low), high(high) {}
+    };
     const std::vector<Commodity> &Commodities() const;
     // Map a price to a value between 0 and 1 (lowest vs. highest).
     double MapPrice(const QString &commodity, int price) const;

--- a/Map.h
+++ b/Map.h
@@ -28,9 +28,12 @@ class StellarObject;
 
 class Map {
 public:
+    // Load from the given file, and remember which file was read from.
     void Load(const QString &path);
-    void Save(const QString &path) const;
+    // Write all the information, and remember which file was chosen.
+    void Save(const QString &path);
     const QString &DataDirectory() const;
+    const QString &FileName() const;
 
     // Mark this file as changed.
     void SetChanged(bool changed = true);
@@ -63,6 +66,7 @@ public:
 
 private:
     QString dataDirectory;
+    QString fileName;
 
     std::list<Galaxy> galaxies;
     std::map<QString, System> systems;

--- a/Planet.h
+++ b/Planet.h
@@ -103,8 +103,8 @@ private:
     QString music;
     QString tributeFleetName;
 
+    // Use a vector so the printing order is preserved.
     std::vector<QString> attributes;
-
     std::vector<QString> shipyard;
     std::vector<QString> outfitter;
 

--- a/PlanetView.cpp
+++ b/PlanetView.cpp
@@ -195,6 +195,7 @@ void PlanetView::SetPlanet(StellarObject *object)
 }
 
 
+
 void PlanetView::Reinitialize()
 {
     SetPlanet(nullptr);
@@ -461,7 +462,7 @@ vector<QString> PlanetView::ToList(const QString &str)
 
     QStringList strings = str.split(",", QString::SkipEmptyParts);
     for(const QString &token : strings)
-        result.push_back(token.trimmed());
+        result.emplace_back(token.trimmed());
 
     return result;
 }

--- a/PlanetView.cpp
+++ b/PlanetView.cpp
@@ -30,6 +30,13 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 using namespace std;
 
+namespace {
+    double GetOptionalValue(const QString &text)
+    {
+        return text.isEmpty() ? numeric_limits<double>::quiet_NaN() : text.toDouble();
+    }
+}
+
 
 
 PlanetView::PlanetView(Map &mapData, QWidget *parent) :
@@ -209,27 +216,31 @@ void PlanetView::NameChanged()
     if(!object || object->GetPlanet() == name->text() || name->text().isEmpty())
         return;
 
-    auto it = mapData.Planets().find(name->text());
-    if(it != mapData.Planets().end())
+    if(mapData.Planets().count(name->text()))
     {
         QMessageBox::warning(this, "Duplicate name",
             "A planet named \"" + name->text() + "\" already exists.");
     }
     else
     {
+        // Copy the planet data from the old name to the new name..
         mapData.RenamePlanet(object, name->text());
+
+        // Update (or create, if not previously a planet) the new name's data.
         Planet &planet = mapData.Planets()[name->text()];
         planet.Attributes() = ToList(attributes->text());
         planet.SetLandscape(landscape->Landscape());
         landscape->SetPlanet(&planet);
         planet.SetDescription(description->toPlainText());
         planet.SetSpaceportDescription(spaceport->toPlainText());
+
         if(!reputation->text().isEmpty())
             planet.SetRequiredReputation(reputation->text().toDouble());
         if(!bribe->text().isEmpty())
             planet.SetBribe(bribe->text().toDouble());
         if(!security->text().isEmpty())
             planet.SetSecurity(security->text().toDouble());
+
         mapData.SetChanged();
     }
 }
@@ -320,9 +331,7 @@ void PlanetView::ReputationChanged()
 {
     if(object && !object->GetPlanet().isEmpty())
     {
-        double value = numeric_limits<double>::quiet_NaN();
-        if(!reputation->text().isEmpty())
-            value = reputation->text().toDouble();
+        double value = GetOptionalValue(reputation->text());
         Planet &planet = mapData.Planets()[object->GetPlanet()];
         if(planet.RequiredReputation() != value || std::isnan(planet.RequiredReputation()) != std::isnan(value))
         {
@@ -338,9 +347,7 @@ void PlanetView::BribeChanged()
 {
     if(object && !object->GetPlanet().isEmpty())
     {
-        double value = numeric_limits<double>::quiet_NaN();
-        if(!bribe->text().isEmpty())
-            value = bribe->text().toDouble();
+        double value = GetOptionalValue(bribe->text());
         Planet &planet = mapData.Planets()[object->GetPlanet()];
         if(planet.Bribe() != value || std::isnan(planet.Bribe()) != std::isnan(value))
         {
@@ -356,9 +363,7 @@ void PlanetView::SecurityChanged()
 {
     if(object && !object->GetPlanet().isEmpty())
     {
-        double value = numeric_limits<double>::quiet_NaN();
-        if(!security->text().isEmpty())
-            value = security->text().toDouble();
+        double value = GetOptionalValue(security->text());
         Planet &planet = mapData.Planets()[object->GetPlanet()];
         if(planet.Security() != value || std::isnan(planet.Security()) != std::isnan(value))
         {
@@ -374,9 +379,7 @@ void PlanetView::TributeChanged()
 {
     if(object && !object->GetPlanet().isEmpty())
     {
-        double value = numeric_limits<double>::quiet_NaN();
-        if(!tribute->text().isEmpty())
-            value = tribute->text().toDouble();
+        double value = GetOptionalValue(tribute->text());
         Planet &planet = mapData.Planets()[object->GetPlanet()];
         if(planet.Tribute() != value || std::isnan(planet.Tribute()) != std::isnan(value))
         {
@@ -392,9 +395,7 @@ void PlanetView::TributeThresholdChanged()
 {
     if(object && !object->GetPlanet().isEmpty())
     {
-        double value = numeric_limits<double>::quiet_NaN();
-        if(!tributeThreshold->text().isEmpty())
-            value = tributeThreshold->text().toDouble();
+        double value = GetOptionalValue(tributeThreshold->text());
         Planet &planet = mapData.Planets()[object->GetPlanet()];
         if(planet.TributeThreshold() != value || std::isnan(planet.TributeThreshold()) != std::isnan(value))
         {
@@ -410,9 +411,7 @@ void PlanetView::TributeFleetQuantityChanged()
 {
     if(object && !object->GetPlanet().isEmpty())
     {
-        double value = numeric_limits<double>::quiet_NaN();
-        if(!tributeFleetQuantity->text().isEmpty())
-            value = tributeFleetQuantity->text().toDouble();
+        double value = GetOptionalValue(tributeFleetQuantity->text());
         Planet &planet = mapData.Planets()[object->GetPlanet()];
         if(planet.TributeFleetQuantity() != value || std::isnan(planet.TributeFleetQuantity()) != std::isnan(value))
         {
@@ -428,11 +427,11 @@ void PlanetView::TributeFleetNameChanged()
 {
     if(object && !object->GetPlanet().isEmpty())
     {
-        QString newDescription = tributeFleetName->text();
+        QString newFleetName = tributeFleetName->text();
         Planet &planet = mapData.Planets()[object->GetPlanet()];
-        if(planet.TributeFleetName() != newDescription)
+        if(planet.TributeFleetName() != newFleetName)
         {
-            planet.SetTributeFleetName(newDescription);
+            planet.SetTributeFleetName(newFleetName);
             mapData.SetChanged();
         }
     }

--- a/PlanetView.cpp
+++ b/PlanetView.cpp
@@ -170,33 +170,34 @@ void PlanetView::SetPlanet(StellarObject *object)
     }
     else
     {
-        name->setText(it->second.Name());
-        attributes->setText(ToString(it->second.Attributes()));
-        landscape->SetPlanet(&it->second);
+        Planet &planet = it->second;
+        name->setText(planet.Name());
+        attributes->setText(ToString(planet.Attributes()));
+        landscape->SetPlanet(&planet);
 
         disconnect(description, SIGNAL(textChanged()), this, SLOT(DescriptionChanged()));
-        description->setPlainText(it->second.Description());
+        description->setPlainText(planet.Description());
         connect(description, SIGNAL(textChanged()), this, SLOT(DescriptionChanged()));
 
         disconnect(spaceport, SIGNAL(textChanged()), this, SLOT(SpaceportDescriptionChanged()));
-        spaceport->setPlainText(it->second.SpaceportDescription());
+        spaceport->setPlainText(planet.SpaceportDescription());
         connect(spaceport, SIGNAL(textChanged()), this, SLOT(SpaceportDescriptionChanged()));
 
-        shipyard->setText(ToString(it->second.Shipyard()));
-        outfitter->setText(ToString(it->second.Outfitter()));
-        reputation->setText(std::isnan(it->second.RequiredReputation()) ?
-            QString() : QString::number(it->second.RequiredReputation()));
-        bribe->setText(std::isnan(it->second.Bribe()) ?
-            QString() : QString::number(it->second.Bribe()));
-        security->setText(std::isnan(it->second.Security()) ?
-            QString() : QString::number(it->second.Security()));
-        tribute->setText(std::isnan(it->second.Tribute()) ?
-            QString() : QString::number(it->second.Tribute()));
-        tributeThreshold->setText(std::isnan(it->second.TributeThreshold()) ?
-            QString() : QString::number(it->second.TributeThreshold()));
-        tributeFleetName->setText(it->second.TributeFleetName());
-        tributeFleetQuantity->setText(std::isnan(it->second.TributeFleetQuantity()) ?
-            QString() : QString::number(it->second.TributeFleetQuantity()));
+        shipyard->setText(ToString(planet.Shipyard()));
+        outfitter->setText(ToString(planet.Outfitter()));
+        reputation->setText(std::isnan(planet.RequiredReputation()) ?
+            QString() : QString::number(planet.RequiredReputation()));
+        bribe->setText(std::isnan(planet.Bribe()) ?
+            QString() : QString::number(planet.Bribe()));
+        security->setText(std::isnan(planet.Security()) ?
+            QString() : QString::number(planet.Security()));
+        tribute->setText(std::isnan(planet.Tribute()) ?
+            QString() : QString::number(planet.Tribute()));
+        tributeThreshold->setText(std::isnan(planet.TributeThreshold()) ?
+            QString() : QString::number(planet.TributeThreshold()));
+        tributeFleetName->setText(planet.TributeFleetName());
+        tributeFleetQuantity->setText(std::isnan(planet.TributeFleetQuantity()) ?
+            QString() : QString::number(planet.TributeFleetQuantity()));
 
     }
 }

--- a/SpriteSet.cpp
+++ b/SpriteSet.cpp
@@ -68,8 +68,7 @@ QPixmap SpriteSet::Get(const QString &name)
 // Set an entry in the set (using an image loaded elsewhere).
 void SpriteSet::Set(const QString &name, QImage image)
 {
-    auto it = sprite.find(name);
-    if(it != sprite.end())
+    if(sprite.count(name))
         return;
 
     sprite[name] = QPixmap::fromImage(image);

--- a/StellarObject.cpp
+++ b/StellarObject.cpp
@@ -234,8 +234,8 @@ double StellarObject::Period() const
 // Get the radius of this planet, i.e. how close you must be to land.
 double StellarObject::Radius() const
 {
-    auto it = INFO.find(sprite);
-    return (it != INFO.end() ? it->second.radius : 40);
+    const auto &it = INFO.find(sprite);
+    return (it != INFO.end() ? it->second.radius : 40.);
 }
 
 
@@ -386,7 +386,7 @@ bool StellarObject::IsInhabited() const
     if(IsStation())
         return true;
 
-    auto it = INFO.find(sprite);
+    const auto &it = INFO.find(sprite);
     return(it != INFO.end() && it->second.info == 2);
 }
 

--- a/StellarObject.cpp
+++ b/StellarObject.cpp
@@ -234,7 +234,7 @@ double StellarObject::Period() const
 // Get the radius of this planet, i.e. how close you must be to land.
 double StellarObject::Radius() const
 {
-    const auto &it = INFO.find(sprite);
+    auto it = INFO.find(sprite);
     return (it != INFO.end() ? it->second.radius : 40.);
 }
 
@@ -386,7 +386,7 @@ bool StellarObject::IsInhabited() const
     if(IsStation())
         return true;
 
-    const auto &it = INFO.find(sprite);
+    auto it = INFO.find(sprite);
     return(it != INFO.end() && it->second.info == 2);
 }
 

--- a/StellarObject.h
+++ b/StellarObject.h
@@ -27,6 +27,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 // objects in each system move slightly in their orbits.
 class StellarObject {
 public:
+    StellarObject() = default;
+    StellarObject(int parent) : parent(parent) {};
+
     // Some objects do not have sprites, because they are just an orbital
     // center for two or more other objects.
     const QString &Sprite() const;

--- a/System.cpp
+++ b/System.cpp
@@ -64,7 +64,7 @@ void System::Load(const DataNode &node)
         else if(child.Token(0) == "music" && child.Size() >= 2)
             music = child.Token(1);
         else if(child.Token(0) == "link" && child.Size() >= 2)
-            links.push_back(child.Token(1));
+            links.emplace(child.Token(1));
         else if(child.Token(0) == "asteroids" && child.Size() >= 4)
             asteroids.emplace_back(child.Token(1), static_cast<int>(child.Value(2)), child.Value(3));
         else if(child.Token(0) == "trade" && child.Size() >= 3)
@@ -143,7 +143,7 @@ const QString &System::Government() const
 
 
 // Get a list of systems you can travel to through hyperspace from here.
-const vector<QString> &System::Links() const
+const set<QString> &System::Links() const
 {
     return links;
 }
@@ -384,34 +384,29 @@ void System::SetGovernment(const QString &gov)
 
 
 
+// Either create or destroy a linking set with the pointed System.
 void System::ToggleLink(System *other)
 {
     if(!other || other == this)
         return;
 
-    auto it = find(links.begin(), links.end(), other->name);
-    auto oit = find(other->links.begin(), other->links.end(), name);
-    if(it == links.end())
-    {
-        links.push_back(other->name);
-        if(oit == other->links.end())
-            other->links.push_back(name);
-    }
+    if(links.erase(other->name))
+        other->links.erase(name);
     else
     {
-        links.erase(it);
-        if(oit != other->links.end())
-            other->links.erase(oit);
+        // These systems were not linked, so link them.
+        links.emplace(other->name);
+        other->links.emplace(name);
     }
 }
 
 
 
+// Change the name of a linked System.
 void System::ChangeLink(const QString &from, const QString &to)
 {
-    auto it = find(links.begin(), links.end(), from);
-    if(it != links.end())
-        *it = to;
+    if(links.erase(from))
+        links.emplace(to);
 }
 
 

--- a/System.cpp
+++ b/System.cpp
@@ -666,7 +666,7 @@ void System::ChangeSprite(StellarObject *object)
             else
                 newObject = StellarObject::Uninhabited();
         }
-    } while(used.find(newObject.Sprite()) != used.end());
+    } while(used.count(newObject.Sprite()));
 
     // Check how much the radius will change by, then change the sprite.
     double radiusChange = newObject.Radius() - object->Radius();
@@ -752,7 +752,7 @@ void System::AddPlanet()
             root = isHabitable ? StellarObject::Planet() : StellarObject::Uninhabited();
         else
             root = StellarObject::Giant();
-    } while(used.find(root.Sprite()) != used.end());
+    } while(used.count(root.Sprite()));
     objects.push_back(root);
     used.insert(root.Sprite());
 
@@ -772,7 +772,7 @@ void System::AddPlanet()
         StellarObject moon;
         do {
             moon = StellarObject::Moon();
-        } while(used.find(moon.Sprite()) != used.end());
+        } while(used.count(moon.Sprite()));
         used.insert(moon.Sprite());
 
         moon.distance = moonDistance + moon.Radius();
@@ -808,7 +808,7 @@ void System::AddMoon(StellarObject *object, bool isStation)
     StellarObject moon;
     do {
         moon = isStation ? StellarObject::Station() : StellarObject::Moon();
-    } while(used.find(moon.Sprite()) != used.end());
+    } while(used.count(moon.Sprite()));
 
     moon.distance = moonDistance + moon.Radius();
     moon.parent = rootIndex;

--- a/System.cpp
+++ b/System.cpp
@@ -247,7 +247,7 @@ const vector<System::Minable> &System::Minables() const
 // Get the price of the given commodity in this system.
 int System::Trade(const QString &commodity) const
 {
-    const auto &it = trade.find(commodity);
+    auto it = trade.find(commodity);
     return (it == trade.end()) ? 0 : it->second;
 }
 

--- a/System.cpp
+++ b/System.cpp
@@ -402,10 +402,11 @@ void System::ToggleLink(System *other)
 
 
 
-// Change the name of a linked System.
+// Change the name of a linked System. If the new name is empty, this
+// effectively deletes the link.
 void System::ChangeLink(const QString &from, const QString &to)
 {
-    if(links.erase(from))
+    if(links.erase(from) && !to.isEmpty())
         links.emplace(to);
 }
 

--- a/System.h
+++ b/System.h
@@ -34,9 +34,18 @@ class Planet;
 // objects in each system, and the hyperspace links between systems.
 class System {
 public:
-    struct Asteroid { QString type; int count; double energy; };
-    struct Fleet { QString name; int period; };
-    struct Minable { QString type; int count; double energy; };
+    struct Asteroid {
+        QString type; int count; double energy;
+        Asteroid(const QString &type, int count, double energy) : type(type), count(count), energy(energy) {}
+    };
+    struct Fleet {
+        QString name; int period;
+        Fleet(const QString &name, int period) : name(name), period(period) {}
+    };
+    struct Minable {
+        QString type; int count; double energy;
+        Minable(const QString &type, int count, double energy) : type(type), count(count), energy(energy) {}
+    };
 
 
 public:
@@ -71,6 +80,7 @@ public:
     // Get the specification of how many minables of each type there are.
     std::vector<Minable> &Minables();
     const std::vector<Minable> &Minables() const;
+
     // Get the price of the given commodity in this system.
     int Trade(const QString &commodity) const;
 

--- a/System.h
+++ b/System.h
@@ -60,7 +60,7 @@ public:
     const QString &Government() const;
 
     // Get a list of systems you can travel to through hyperspace from here.
-    const std::vector<QString> &Links() const;
+    const std::set<QString> &Links() const;
 
     // Get the stellar object locations on the most recently set date.
     std::vector<StellarObject> &Objects();
@@ -127,7 +127,7 @@ private:
     QString government;
 
     // Hyperspace links to other systems.
-    std::vector<QString> links;
+    std::set<QString> links;
 
     // Stellar objects, listed in such an order that an object's parents are
     // guaranteed to appear before it (so that if we traverse the vector in

--- a/SystemView.cpp
+++ b/SystemView.cpp
@@ -270,6 +270,7 @@ void SystemView::mousePressEvent(QMouseEvent *event)
     if(event->button() != Qt::LeftButton)
     {
         selectedObject = nullptr;
+        update();
         return;
     }
     else if(!system)

--- a/SystemView.h
+++ b/SystemView.h
@@ -79,7 +79,9 @@ private:
     Map &mapData;
     DetailView *detailView;
     QTabWidget *tabs;
+    // The detail view for the selected Planet object.
     PlanetView *planetView;
+    // The current system being accessed and drawn.
     System *system = nullptr;
     StellarObject *selectedObject = nullptr;
 

--- a/SystemView.h
+++ b/SystemView.h
@@ -69,8 +69,10 @@ protected:
 
     virtual void paintEvent(QPaintEvent *event) override;
 
+
 private:
     QVector2D MapPoint(QPoint pos) const;
+    void DidChange();
 
 
 private:


### PR DESCRIPTION
I'll update this post to provide a better summary:

Bug fixes
 - nullptr dereferences if opening a new map and clicking
 - Changing a system name with keyboard confirmation could double-execute, and could result in modifying a deleted object
 - `end()` dereferencing

Features
 - Prompt for unsaved changes
 - "Recenter" option on the menu
 - "Create System" menu
 - "Save" and "Save As" functionality

Other
 - Fewer horizontal scrollbars
 - Fewer vertical scrollbars
 - Fleets & minables display is now cleared if the selected system is deleted
 - view updates after changing selections (including updating the government color if coloring by government)