### PR TITLE
Add an actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,10 @@ jobs:
     strategy:
       matrix:
         target:
-          - linux
-          - windows
-          - macos
+          - ubuntu-latest
+          - ubuntu-18.04
+          - windows-latest
+          - macos-latest
         include:
           - target: ubuntu-latest
             artifact: endless-sky-editor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         version: "5.15.2"
         dir: ${{ github.workspace }}/Qt/
-        arch: win64_mingw81 # This is only used (and needed on windows, so we can safely specify it for all OSes
+        arch: win64_mingw81 # This is only used (and needed) on windows, so we can safely specify it for all OSes
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         
     - name: Run qmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,3 @@ jobs:
       with:
         name: ${{ matrix.target }}
         path: ${{ matrix.artifact }}
-        
-    
-    
-    
-    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, actions ] # TODO
+  pull_request:
+    branches: [ master, actions ] # TODO
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: test
+      run: echo foo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+
     - uses: actions/checkout@v2
 
     - name: Cache Qt
@@ -55,9 +56,7 @@ jobs:
       
     - name: Run make
       run: make -j $(nproc)
-      
-    - run: |
-        git status
+
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize]
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,20 @@ jobs:
           - windows
           - macos
         include:
-          - target: linux
-            os: ubuntu-latest
+          - target: ubuntu-latest
             artifact: endless-sky-editor
             binary: endless-sky-editor
-          - target: windows
-            os: windows-latest
+          - target: ubuntu-18.04
+            artifact: endless-sky-editor
+            binary: endless-sky-editor
+          - target: windows-latest
             artifact: release/endless-sky-editor.exe
             binary: release/endless-sky-editor.exe
-          - target: macos
-            os: macos-latest
+          - target: macos-latest
             artifact: endless-sky-editor.app/
             binary: endless-sky-editor.app/Contents/MacOS/endless-sky-editor
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.target }}
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - actions
   pull_request:
     types: [opened, synchronize]
 
@@ -17,11 +16,6 @@ jobs:
   
     strategy:
       matrix:
-        target:
-          - ubuntu-latest
-          - ubuntu-18.04
-          - windows-latest
-          - macos-latest
         include:
           - target: ubuntu-latest
             artifact: endless-sky-editor
@@ -39,9 +33,7 @@ jobs:
     runs-on: ${{ matrix.target }}
 
     steps:
-
     - uses: actions/checkout@v2
-
     - name: Cache Qt
       id: cache-qt
       uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,13 @@ jobs:
         dir: ${{ github.workspace }}/Qt/
         arch: win64_mingw81 # This is only used (and needed) on windows, so we can safely specify it for all OSes
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
-        
+
     - name: Run qmake
       run: qmake
-      
+
     - name: Run make
       run: make -j $(nproc)
-      
+
     - name: Run --version
       run: ./${{ matrix.binary }} --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-  pull_request:
-  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             artifact: endless-sky-editor
           - target: windows
             os: windows-latest
-            artifact: endless-sky-editor.exe
+            artifact: release/endless-sky-editor.exe
           - target: macos
             os: macos-latest
             artifact: endless-sky-editor
@@ -58,8 +58,6 @@ jobs:
       
     - run: |
         git status
-        ls -la
-        ls -la release
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ master, actions ] # TODO
   pull_request:
-    branches: [ master, actions ] # TODO
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: "4.8"
+        version: "5.15.2"
         dir: '${{ github.workspace }}/Qt/'
         cached: ${{ steps.cache-qt.outputs.cache-hit }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,31 @@ on:
   pull_request:
     branches: [ master, actions ] # TODO
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
+  
+    strategy:
+      matrix:
+        target:
+          - linux
+          - windows
+          - macos
+        include:
+          - target: linux
+            os: ubuntu-latest
+            artifact: endless-sky-editor
+          - target: windows
+            os: windows-latest
+            artifact: endless-sky-editor.exe
+          - target: macos
+            os: macos-latest
+            artifact: endless-sky-editor
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
@@ -37,8 +58,9 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
-        name: endless-sky-editor-amd64
-        path: endless-sky-editor
+        name: ${{ matrix.target }}
+        path: ${{ matrix.artifact }}
+        
     
     
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,9 @@ jobs:
       run: make -j $(nproc)
       
     - run: |
+        git status
         ls -la
-        ls la release
+        ls -la release
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,15 @@ jobs:
           - target: linux
             os: ubuntu-latest
             artifact: endless-sky-editor
+            binary: endless-sky-editor
           - target: windows
             os: windows-latest
             artifact: release/endless-sky-editor.exe
+            binary: release/endless-sky-editor.exe
           - target: macos
             os: macos-latest
             artifact: endless-sky-editor.app/
+            binary: endless-sky-editor.app/Contents/MacOS/endless-sky-editor
 
     runs-on: ${{ matrix.os }}
 
@@ -53,6 +56,9 @@ jobs:
       
     - name: Run make
       run: make -j $(nproc)
+      
+    - name: Run --version
+      run: ${{ matrix.binary }} --version
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       run: make -j $(nproc)
       
     - name: Run --version
-      run: ${{ matrix.binary }} --version
+      run: ./${{ matrix.binary }} --version
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: test
-      run: echo foo
+
+    - name: Cache Qt
+      id: cache-qt
+      uses: actions/cache@v1
+      with:
+        path: '${{ github.workspace }}/Qt/'
+        key: ${{ runner.os }}-QtCache
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: "4.8"
+        dir: '${{ github.workspace }}/Qt/'
+        cached: ${{ steps.cache-qt.outputs.cache-hit }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,15 @@ jobs:
       id: cache-qt
       uses: actions/cache@v1
       with:
-        path: '${{ github.workspace }}/Qt/'
+        path: ${{ github.workspace }}/Qt/
         key: ${{ runner.os }}-QtCache
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
         version: "5.15.2"
-        dir: '${{ github.workspace }}/Qt/'
+        dir: ${{ github.workspace }}/Qt/
+        arch: win64_mingw81 # This is only used (and needed on windows, so we can safely specify it for all OSes
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         
     - name: Run qmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             artifact: release/endless-sky-editor.exe
           - target: macos
             os: macos-latest
-            artifact: endless-sky-editor
+            artifact: endless-sky-editor.app/
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
       
     - name: Run make
       run: make -j $(nproc)
+      
+    - run: ls -la
         
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - actions
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,13 @@ jobs:
         version: "5.15.2"
         dir: '${{ github.workspace }}/Qt/'
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
+        
+    - name: Run qmake
+      run: qmake
+      
+    - name: Run make
+      run: make -j $(nproc)
+    
+    
+    
+    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
       
     - name: Run make
       run: make -j $(nproc)
+        
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: endless-sky-editor-amd64
+        path: endless-sky-editor
     
     
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,9 @@ jobs:
     - name: Run make
       run: make -j $(nproc)
       
-    - run: ls -la
-        
+    - run: |
+        ls -la
+        ls la release
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
**Feature:** This PR adds a CI pipeline via Github Actions

## Feature Details
- runs on every change (push to master, PR)
- produces native artifacts for
	- ubuntu-latest (currently 20.04)
	- ubuntu-18.04
	- windows-latest (currently 2019)
	- macos-latest (currently 11)
## Testing Done
Pipeline: <https://github.com/MCOfficer/endless-sky-editor/actions?query=branch%3Aactions>

Artifacts:
- [x] Linux
- [x] Windows
- [ ] macOS

## Performance
Qt is cached between runs, so the pipeline averages ~90 seconds for any workflow run.

