### PR TITLE
fix for issue-31: Save button doesn't work

### DIFF
--- a/Map.cpp
+++ b/Map.cpp
@@ -16,8 +16,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DataWriter.h"
 #include "SpriteSet.h"
 
-#include <QString>
 #include <QFileInfo>
+#include <QString>
 
 #include <algorithm>
 

--- a/Map.cpp
+++ b/Map.cpp
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "SpriteSet.h"
 
 #include <QString>
+#include <QFileInfo>
 
 #include <algorithm>
 
@@ -29,8 +30,10 @@ void Map::Load(const QString &path)
     // Clear everything first.
     *this = Map();
 
-    dataDirectory = path.left(path.lastIndexOf('/'));
-    fileName = path.right(path.lastIndexOf('/'));
+    QFileInfo p = QFileInfo(path);
+
+    dataDirectory = p.absolutePath();
+    fileName = p.fileName();
     QString rootDir = dataDirectory.left(dataDirectory.lastIndexOf('/'));
     dataDirectory += "/";
     SpriteSet::SetRootPath(rootDir + "/images/");
@@ -68,7 +71,9 @@ void Map::Load(const QString &path)
 
 void Map::Save(const QString &path)
 {
-    fileName = path.right(path.lastIndexOf('/'));
+    QFileInfo p = QFileInfo(path);
+
+    fileName = p.fileName();
     DataWriter file(path);
     file.WriteRaw(comments);
     file.Write();


### PR DESCRIPTION
The problem of the save functionality came from the fact that the QString::right() method expects the number of characters it should take from the end of the string forward. The lastIndexOf() method finds the last occurence of a character but returns the index from the beginning of the string.
Now instead of counting length of "filename+extension" from the end, the right function counted the number of characters from the end, resulting in an invalid path in the save method.
To reduce errors in this area I replaced the QString methods with the QFileInfo methods that take care of these things and is therefore more safe. 